### PR TITLE
エラー系で debounce や promise rejection で意図せぬ動作を修正

### DIFF
--- a/composables/use-content-contact.ts
+++ b/composables/use-content-contact.ts
@@ -57,7 +57,7 @@ export const useContactRead = (customerId: Ref<number | null>) => {
 }
 
 export const useContactWrite = (customerId: Ref<number | null>) => {
-  const { create, update, remove, updateImageSettings } = useContentWrite<
+  const { create, update, remove, useUpdateImageSettings } = useContentWrite<
     ContactSaveApi,
     ContactGetApi
   >(customerId, apiUrl)
@@ -129,14 +129,12 @@ export const useContactWrite = (customerId: Ref<number | null>) => {
     }
   }
 
+  const { debouncedFunc } = useUpdateImageSettings()
   const updateContactImageSettings = async (
     contentId: number,
     imageSettings: ImageSettings
   ) => {
-    const promise = updateImageSettings(contentId, imageSettings)
-    if (promise) {
-      return await promise
-    }
+    debouncedFunc(contentId, imageSettings)
   }
 
   return {

--- a/composables/use-content-eyecatch.ts
+++ b/composables/use-content-eyecatch.ts
@@ -54,7 +54,7 @@ const useEyecatchRead = (customerId: Ref<number | null>) => {
 }
 
 const useEyecatchWrite = (customerId: Ref<number | null>) => {
-  const { create, update, remove, updateImageSettings } = useContentWrite<
+  const { create, update, remove, useUpdateImageSettings } = useContentWrite<
     EyecatchSaveApi,
     EyecatchGetApi
   >(customerId, apiUrl)
@@ -122,14 +122,12 @@ const useEyecatchWrite = (customerId: Ref<number | null>) => {
     }
   }
 
-  const updateEyecatchImageSettings = async (
+  const { debouncedFunc } = useUpdateImageSettings()
+  const updateEyecatchImageSettings = (
     contentId: number,
     imageSettings: ImageSettings
   ) => {
-    const promise = updateImageSettings(contentId, imageSettings)
-    if (promise) {
-      return await promise
-    }
+    debouncedFunc(contentId, imageSettings)
   }
 
   return {

--- a/composables/use-content-information.ts
+++ b/composables/use-content-information.ts
@@ -61,7 +61,7 @@ const useInformationRead = (customerId: Ref<number | null>) => {
 }
 
 const useInformationWrite = (customerId: Ref<number | null>) => {
-  const { create, update, remove, updateImageSettings } = useContentWrite<
+  const { create, update, remove, useUpdateImageSettings } = useContentWrite<
     InformationSaveApi,
     InformationGetApi
   >(customerId, apiUrl)
@@ -132,14 +132,12 @@ const useInformationWrite = (customerId: Ref<number | null>) => {
     }
   }
 
+  const { debouncedFunc } = useUpdateImageSettings()
   const updateInformationImageSettings = async (
     contentId: number,
     imageSettings: ImageSettings
   ) => {
-    const promise = updateImageSettings(contentId, imageSettings)
-    if (promise) {
-      return await promise
-    }
+    debouncedFunc(contentId, imageSettings)
   }
 
   return {

--- a/composables/use-content-news.ts
+++ b/composables/use-content-news.ts
@@ -108,7 +108,7 @@ const useNewsRead = (customerId: Ref<number | null>) => {
 }
 
 const useNewsWrite = (customerId: Ref<number | null>) => {
-  const { create, update, remove, updateImageSettings } = useContentWrite<
+  const { create, update, remove, useUpdateImageSettings } = useContentWrite<
     NewsSaveApi,
     NewsGetApi
   >(customerId, apiUrl)
@@ -182,14 +182,12 @@ const useNewsWrite = (customerId: Ref<number | null>) => {
     }
   }
 
+  const { debouncedFunc } = useUpdateImageSettings()
   const updateNewsImageSettings = async (
     contentId: number,
     imageSettings: ImageSettings
   ) => {
-    const promise = updateImageSettings(contentId, imageSettings)
-    if (promise) {
-      return await promise
-    }
+    debouncedFunc(contentId, imageSettings)
   }
 
   return {
@@ -295,12 +293,15 @@ export const useNewsListActions = (customerId: Ref<number | null>) => {
     loading: writeLoading,
   } = useNewsWrite(customerId)
 
+  const { addSnackber } = useSnackbars()
+
   const onLoad = async () => {
     await getNewsList(filter.value, sort.value, pager.value)
   }
 
   const onCreate = async (formData: NewsForm) => {
     await createNews(formData)
+    addSnackber?.('News を登録しました。')
     nextKey()
     getNewsList(filter.value, sort.value, pager.value)
   }
@@ -315,12 +316,14 @@ export const useNewsListActions = (customerId: Ref<number | null>) => {
     if (!id) return
 
     await updateNews(id, formData)
+    addSnackber?.('News を更新しました。')
     nextKey()
     getNewsList(filter.value, sort.value, pager.value)
   }
 
   const onRemove = async (id: number) => {
     await removeNews(id)
+    addSnackber?.('News を削除しました。')
     nextKey()
     getNewsList(filter.value, sort.value, pager.value)
   }


### PR DESCRIPTION
エラー系

lodash.debounce では return で data や error を返すのはできなかったので、ref の変数にセットしてそれを watch する形でエラー検知するように修正した。

また、computed の set で in promise の rejection がきちんと catch されていないと "Unhandled promise rejection" となってしまい Nuxt エラーハンドリングされなかったので、こちらも error をref の変数にセットしてそれを watch する形でエラー検知するように修正した。