### PR TITLE
新規ユーザ初期ページで404エラー画面から抜け出せない問題解消

### DIFF
--- a/plugins/error-handler.ts
+++ b/plugins/error-handler.ts
@@ -22,6 +22,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       })
     }
   }
+
   const handleError = async (error: any) => {
     if ('statusCode' in error && 'message' in error) {
       handleNuxtError(error)


### PR DESCRIPTION
本質的な問題はBACKEND側にあったのでBACKENDを修正