### PR TITLE
リッチテキストの表示スタイルや挙動をリファクタリング

### DIFF
--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -49,7 +49,7 @@ a:active {
 
 blockquote {
   border-left: 5px solid #ddd;
-  padding: 1rem 0 1rem 1.5rem;
+  padding-left: 1rem !important;
 }
 
 // 画面サイズに応じて表示したり非表示にしたりする

--- a/assets/css/_theme_default.scss
+++ b/assets/css/_theme_default.scss
@@ -59,7 +59,7 @@
     --g-theme-wysiwyg-editor-label-color: #{variables.$gray-lighten1};
     --g-theme-wysiwyg-editor-label-focused-color: #{variables.$gray-darken1};
     --g-theme-wysiwyg-editor-placeholder-color: #{variables.$dimgray};
-    --g-theme-wysiwyg-editor-hovered-background-color: #{variables.$gray-lighten3};
-    --g-theme-wysiwyg-editor-focused-background-color: #{variables.$gray-lighten4};
+    --g-theme-wysiwyg-editor-hovered-background-color: #{variables.$gray-lighten4};
+    --g-theme-wysiwyg-editor-focused-background-color: #{variables.$white};
   }
 }

--- a/components/base/dialog.vue
+++ b/components/base/dialog.vue
@@ -3,9 +3,11 @@ const props = withDefaults(
   defineProps<{
     modal: boolean
     maxWidth?: number
+    persistent?: boolean
   }>(),
   {
     maxWidth: 800,
+    persistent: false,
   }
 )
 const emit = defineEmits<{
@@ -21,7 +23,12 @@ const dialog = computed({
 </script>
 
 <template>
-  <v-dialog v-model="dialog" :max-width="maxWidth" scrollable>
+  <v-dialog
+    v-model="dialog"
+    :max-width="maxWidth"
+    :persistent="persistent"
+    scrollable
+  >
     <slot />
   </v-dialog>
 </template>

--- a/components/common/content-edit-dialog.vue
+++ b/components/common/content-edit-dialog.vue
@@ -13,23 +13,39 @@ const dialog = computed({
 </script>
 
 <template>
-  <BaseDialog v-model:modal="dialog">
+  <BaseDialog v-model:modal="dialog" persistent>
     <div class="content-edit-dialog">
       <header class="content-edit-dialog__header">
-        <slot name="header">
-          <template v-if="isUpdate">
-            <p class="mr-1">
-              <v-icon icon="mdi-pencil-circle" color="success" size="x-large" />
-            </p>
-            <h3>コンテンツの更新</h3>
-          </template>
-          <template v-else>
-            <p class="mr-1">
-              <v-icon icon="mdi-plus-circle" color="info" size="x-large" />
-            </p>
-            <h3>コンテンツの追加</h3>
-          </template>
-        </slot>
+        <div class="header-label">
+          <slot name="header">
+            <template v-if="isUpdate">
+              <p class="mr-1">
+                <v-icon
+                  icon="mdi-pencil-circle"
+                  color="success"
+                  size="x-large"
+                />
+              </p>
+              <h3>コンテンツの更新</h3>
+            </template>
+            <template v-else>
+              <p class="mr-1">
+                <v-icon icon="mdi-plus-circle" color="info" size="x-large" />
+              </p>
+              <h3>コンテンツの追加</h3>
+            </template>
+          </slot>
+        </div>
+        <div class="header-dismiss">
+          <v-btn
+            variant="text"
+            append-icon="mdi-close"
+            size="small"
+            color="primary"
+            @click="dialog = false"
+            >閉じる</v-btn
+          >
+        </div>
       </header>
       <div class="content-edit-dialog__body">
         <slot />
@@ -47,8 +63,13 @@ const dialog = computed({
   &__header {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     padding: 1rem;
     border-bottom: 1px solid lightgray;
+    .header-label {
+      display: flex;
+      align-items: center;
+    }
   }
   &__body {
     padding: 1.5rem;

--- a/components/publish/home/type1/contact.vue
+++ b/components/publish/home/type1/contact.vue
@@ -38,7 +38,7 @@ await onLoad()
         </div>
       </CommonEyecatchImage>
       <CommonContentCardBody>
-        <div v-if="contactRef?.body">
+        <div v-if="contactRef?.body" class="ql-editor">
           <div v-html="htmlSanitizer(contactRef?.body)" />
           <div class="inquire-activator">
             <PublishInquire />

--- a/components/publish/home/type1/information.vue
+++ b/components/publish/home/type1/information.vue
@@ -38,7 +38,7 @@ await onLoad()
         </div>
       </CommonEyecatchImage>
       <CommonContentCardBody>
-        <div v-if="informationRef?.body">
+        <div v-if="informationRef?.body" class="ql-editor">
           <div v-html="htmlSanitizer(informationRef?.body)" />
           <div class="inquire-activator">
             <PublishInquire />

--- a/components/publish/home/type1/services.vue
+++ b/components/publish/home/type1/services.vue
@@ -42,7 +42,7 @@ await onLoad()
               class="service-item__eyecatcher"
             />
             <div
-              class="service-item__caption"
+              class="service-item__caption ql-editor"
               v-html="htmlSanitizer((content as ServiceType).caption)"
             />
             <div class="edit-activator">

--- a/components/publish/news/detail.vue
+++ b/components/publish/news/detail.vue
@@ -44,7 +44,7 @@ await onLoad(contentId)
           <h5 class="g-text-cl news-detail__title">
             <span>{{ newsRef?.title ?? '' }}</span>
           </h5>
-          <div v-if="newsRef?.body">
+          <div v-if="newsRef?.body" class="ql-editor">
             <div v-html="htmlSanitizer(newsRef?.body)" />
             <div class="inquire-activator">
               <PublishInquire />

--- a/composables/use-content-contact.ts
+++ b/composables/use-content-contact.ts
@@ -162,7 +162,6 @@ export const useContactForm = () => {
       maxLength(v, 50) || '50文字以内で入力してください',
     body: (v: string | undefined) => {
       if (!noBlankForWysiwyg(v)) return '本文を入力してください'
-      if (!maxLength(v, 1000)) return '1000文字以内で入力してください'
       return true
     },
     image: () => true,

--- a/composables/use-content-information.ts
+++ b/composables/use-content-information.ts
@@ -165,7 +165,6 @@ export const useInformationForm = () => {
       maxLength(v, 50) || '50文字以内で入力してください',
     body: (v: string | undefined) => {
       if (!noBlankForWysiwyg(v)) return '本文を入力してください'
-      if (!maxLength(v, 1000)) return '1000文字以内で入力してください'
       return true
     },
     image: () => true,

--- a/composables/use-content-news.ts
+++ b/composables/use-content-news.ts
@@ -215,7 +215,6 @@ export const useNewsForm = () => {
     publishOn: (v: Date | null) => required(v) || '公開日を入力してください',
     body: (v: string | undefined) => {
       if (!noBlankForWysiwyg(v)) return '本文を入力してください'
-      if (!maxLength(v, 1000)) return '1000文字以内で入力してください'
       return true
     },
     image: () => true,

--- a/composables/use-content-service.ts
+++ b/composables/use-content-service.ts
@@ -219,7 +219,6 @@ export const useServiceForm = () => {
     },
     body: (v: string | undefined) => {
       if (!noBlankForWysiwyg(v)) return '本文を入力してください'
-      if (!maxLength(v, 1000)) return '1000文字以内で入力してください'
       return true
     },
     image: (v: string | undefined) =>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,10 +1,6 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  css: [
-    '~/assets/css/main.scss',
-    'vuetify/styles',
-    '@mdi/font/css/materialdesignicons.css',
-  ],
+  css: ['~/assets/css/main.scss'],
   app: {
     head: {
       title: 'iine-t',


### PR DESCRIPTION
リッチテキストの表示スタイルや挙動をリファクタリング

- 本文の最大文字長を撤廃
- 表示スタイルが一部反映されていなかったので修正
- リッチテキストエディタモーダルをparsistantに
- リッチテキストエディタのスタイルを修正