### PR TITLE
スマホ画面のデザインをもっと使いやすいように見直し

### DIFF
--- a/components/common/content-card-body.vue
+++ b/components/common/content-card-body.vue
@@ -13,7 +13,7 @@
 
 @media only screen and (max-width: $grid-breakpoint-md) {
   .contents-card-body {
-    padding: 2.5rem 1.5rem;
+    padding: 2.5rem 2rem;
   }
 }
 </style>

--- a/components/common/content-card-title.vue
+++ b/components/common/content-card-title.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    title: string
+    subtitle?: string
+    textNoWrap?: boolean
+  }>(),
+  {
+    title: '',
+    subtitle: '',
+    textNoWrap: false,
+  }
+)
+</script>
+
+<template>
+  <div class="content-card-title">
+    <h5 class="g-text-cl" :class="{ 'text-no-wrap': textNoWrap }">
+      {{ title }}
+    </h5>
+    <p
+      v-if="subtitle"
+      class="g-text-cl"
+      :class="{ 'text-no-wrap': textNoWrap }"
+    >
+      {{ subtitle }}
+    </p>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.content-card-title {
+  padding: 1rem 2rem;
+  font-weight: bold;
+  h5 {
+    font-size: 1.4rem;
+  }
+  p {
+    font-size: 1.1rem;
+  }
+}
+
+@media only screen and (max-width: $grid-breakpoint-md) {
+  .content-card-title {
+    h5 {
+      font-size: 1.25rem;
+    }
+    p {
+      font-size: 1rem;
+    }
+  }
+}
+</style>

--- a/components/common/content-card.vue
+++ b/components/common/content-card.vue
@@ -11,21 +11,22 @@ $contents-card-max-width: 1140px;
 $contents-card-min-height: 240px;
 
 .contents-card-wrap {
-  width: 100%;
+  width: 90%;
   max-width: $contents-card-max-width;
   min-height: $contents-card-min-height;
   margin: 0 auto;
   .contents-card {
     min-height: $contents-card-min-height;
     overflow: hidden;
+    border-radius: 12px;
   }
 }
 
-@media only screen and (min-width: $grid-breakpoint-md) {
+@media only screen and (max-width: $grid-breakpoint-md) {
   .contents-card-wrap {
-    width: 90%;
+    width: 100%;
     .contents-card {
-      border-radius: 12px;
+      border-radius: 0;
     }
   }
 }

--- a/components/common/eyecatch-image.vue
+++ b/components/common/eyecatch-image.vue
@@ -39,10 +39,12 @@ const bkImage = computed(() => `url(${props.url.length ? props.url : noImage})`)
   background-position: v-bind('settings.lgPosition');
   background-attachment: v-bind('settings.lgParallax');
 }
+
 .circle {
   border-radius: 50%;
   overflow: hidden;
 }
+
 .round {
   border-radius: 12px;
   overflow: hidden;

--- a/components/common/eyecatch-titles.vue
+++ b/components/common/eyecatch-titles.vue
@@ -5,11 +5,13 @@ withDefaults(
     title?: string
     subtitle?: string
     titleBackgroundTranparent?: number
+    textNoWrap?: boolean
   }>(),
   {
     title: '',
     subtitle: '',
     titleBackgroundTranparent: 0.25,
+    textNoWrap: false,
   }
 )
 </script>
@@ -23,10 +25,18 @@ withDefaults(
       'section-title': place === 'section',
     }"
   >
-    <h2 v-show="title?.length" class="maintitle">
+    <h2
+      v-show="title?.length"
+      class="maintitle"
+      :class="{ 'text-no-wrap': textNoWrap }"
+    >
       {{ title }}
     </h2>
-    <p v-show="subtitle?.length" class="subtitle">
+    <p
+      v-show="subtitle?.length"
+      class="subtitle"
+      :class="{ 'text-no-wrap': textNoWrap }"
+    >
       {{ subtitle }}
     </p>
   </div>
@@ -36,7 +46,6 @@ withDefaults(
 $titleBackGroundTranparent: v-bind(titleBackgroundTranparent);
 
 .eyecatch-title {
-  display: block;
   transform: translate(-50%, -50%);
   max-width: 90%;
   h2,
@@ -44,6 +53,8 @@ $titleBackGroundTranparent: v-bind(titleBackgroundTranparent);
     padding: 0;
     margin: 0;
     max-width: 100%;
+  }
+  .text-no-wrap {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -63,6 +74,7 @@ $titleBackGroundTranparent: v-bind(titleBackgroundTranparent);
     margin-top: 1rem;
   }
 }
+
 .section-title {
   color: white;
   font-weight: bold;
@@ -77,23 +89,42 @@ $titleBackGroundTranparent: v-bind(titleBackgroundTranparent);
   }
 }
 
-@media only screen and (max-width: $grid-breakpoint-md) {
+@media only screen and (max-width: $grid-breakpoint-lg) {
   .top-title {
     font-weight: bolder;
     .maintitle {
-      font-size: 1.9rem;
+      font-size: 2rem;
     }
     .subtitle {
       font-size: 1.25rem;
     }
   }
-
   .section-title {
     .maintitle {
       font-size: 1.3rem;
     }
     .subtitle {
       font-size: 1.1rem;
+    }
+  }
+}
+
+@media only screen and (max-width: $grid-breakpoint-md) {
+  .top-title {
+    font-weight: bolder;
+    .maintitle {
+      font-size: 1.5rem;
+    }
+    .subtitle {
+      font-size: 1.2rem;
+    }
+  }
+  .section-title {
+    .maintitle {
+      font-size: 1.25rem;
+    }
+    .subtitle {
+      font-size: 1rem;
     }
   }
 }

--- a/components/common/eyecatch-titles.vue
+++ b/components/common/eyecatch-titles.vue
@@ -1,9 +1,17 @@
 <script setup lang="ts">
-defineProps<{
-  place: 'top' | 'section'
-  title?: string
-  subtitle?: string
-}>()
+withDefaults(
+  defineProps<{
+    place: 'top' | 'section'
+    title?: string
+    subtitle?: string
+    titleBackgroundTranparent?: number
+  }>(),
+  {
+    title: '',
+    subtitle: '',
+    titleBackgroundTranparent: 0.25,
+  }
+)
 </script>
 
 <template>
@@ -25,12 +33,20 @@ defineProps<{
 </template>
 
 <style lang="scss" scoped>
+$titleBackGroundTranparent: v-bind(titleBackgroundTranparent);
+
 .eyecatch-title {
   display: block;
   transform: translate(-50%, -50%);
-  h2 {
+  max-width: 90%;
+  h2,
+  p {
     padding: 0;
     margin: 0;
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 
@@ -41,19 +57,17 @@ defineProps<{
   text-align: center;
   .maintitle {
     font-size: 2.25rem;
-    white-space: nowrap;
   }
   .subtitle {
     font-size: 1.5rem;
     margin-top: 1rem;
-    white-space: nowrap;
   }
 }
 .section-title {
   color: white;
   font-weight: bold;
   padding: 0.75rem;
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: rgb(0 0 0 / $titleBackGroundTranparent);
   .maintitle {
     font-size: 1.5rem;
   }

--- a/components/common/wysiwsg-viewer.vue
+++ b/components/common/wysiwsg-viewer.vue
@@ -14,14 +14,15 @@ withDefaults(defineProps<{ value?: string | null }>(), {
 <style lang="scss" scoped>
 .wysiwsg-viewer {
   :deep(img) {
+    display: block;
     max-width: 100% !important;
     height: auto !important;
     cursor: auto !important;
   }
 
   :deep(iframe) {
-    border: 0.5rem solid var(--black-contrast);
     display: block;
+    border: 0.5rem solid var(--black-contrast);
     max-width: 100%;
     min-height: 200px;
     min-width: 200px;

--- a/components/publish/home/type1/contact.vue
+++ b/components/publish/home/type1/contact.vue
@@ -26,7 +26,8 @@ await onLoad()
           place="section"
           :title="contactRef?.title"
           :subtitle="contactRef?.subtitle"
-          class="eyecatcher__titles"
+          text-no-wrap
+          class="g-block-lg eyecatcher__titles"
         />
         <div
           v-if="canEdit && contactRef?.image?.settings"
@@ -38,13 +39,18 @@ await onLoad()
           />
         </div>
       </CommonEyecatchImage>
+      <PublishCustomerServiceLinks class="type1-contact__service-links" />
+      <CommonContentCardTitle
+        :title="contactRef?.title ?? ''"
+        :subtitle="contactRef?.subtitle"
+        class="g-block-sm type1-contact__title"
+      />
       <CommonContentCardBody class="type1-contact__body">
         <div v-if="contactRef?.body">
           <CommonWysiwsgViewer :value="contactRef?.body" />
           <div class="inquire-activator">
             <PublishInquire />
           </div>
-          <PublishCustomerServiceLinks class="type1-contact__body--links" />
         </div>
         <div v-else class="no-items">
           <p>データがありません</p>
@@ -79,14 +85,18 @@ await onLoad()
     margin-top: 1.5rem;
     text-align: center;
   }
+  &__service-links {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.25rem;
+    margin-right: 1rem;
+  }
+  &__title {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
   &__body {
-    position: relative;
-    padding-top: 3.25rem;
-    &--links {
-      position: absolute;
-      top: 0.5rem;
-      right: 1rem;
-    }
+    padding-top: 0.5rem;
   }
   .no-items {
     display: flex;
@@ -101,14 +111,13 @@ await onLoad()
 }
 
 $eyecatcher-height: 480px;
-$eyecatcher-height-sm: 600px;
+$eyecatcher-height-sm: 300px;
 
 .eyecatcher {
   position: relative;
   height: 30vh;
-  min-height: 400px;
   max-height: $eyecatcher-height;
-  min-height: calc($eyecatcher-height * 0.6);
+  min-height: calc($eyecatcher-height * 0.7);
   &__titles {
     position: absolute;
     top: 50%;
@@ -123,7 +132,7 @@ $eyecatcher-height-sm: 600px;
 
 @media only screen and (max-width: $grid-breakpoint-md) {
   .eyecatcher {
-    height: 50vh;
+    height: 50vw;
     max-height: $eyecatcher-height-sm;
     min-height: calc($eyecatcher-height-sm * 0.5);
     .image-settings {

--- a/components/publish/home/type1/contact.vue
+++ b/components/publish/home/type1/contact.vue
@@ -68,9 +68,6 @@ await onLoad()
 </template>
 
 <style scoped lang="scss">
-$eyecatcher-height: 500px;
-$eyecatcher-height-sm: 600px;
-
 .type1-contact {
   position: relative;
   .edit-activator {
@@ -102,12 +99,16 @@ $eyecatcher-height-sm: 600px;
     }
   }
 }
+
+$eyecatcher-height: 480px;
+$eyecatcher-height-sm: 600px;
+
 .eyecatcher {
   position: relative;
   height: 30vh;
   min-height: 400px;
   max-height: $eyecatcher-height;
-  min-height: calc($eyecatcher-height * 0.5);
+  min-height: calc($eyecatcher-height * 0.6);
   &__titles {
     position: absolute;
     top: 50%;

--- a/components/publish/home/type1/eyecatcher.vue
+++ b/components/publish/home/type1/eyecatcher.vue
@@ -27,6 +27,7 @@ await onLoad()
         place="top"
         :title="eyecatchRef?.title"
         :subtitle="eyecatchRef?.subtitle"
+        text-no-wrap
         class="titles"
       />
       <div
@@ -83,8 +84,11 @@ await onLoad()
 }
 @media only screen and (max-width: $grid-breakpoint-md) {
   .eyecatcher {
-    height: 100vh;
+    height: 75vh;
     min-height: auto;
+    .titles {
+      top: 65%;
+    }
     .image-settings {
       bottom: 0.5rem;
       right: 0.5rem;

--- a/components/publish/home/type1/information.vue
+++ b/components/publish/home/type1/information.vue
@@ -66,9 +66,6 @@ await onLoad()
 </template>
 
 <style scoped lang="scss">
-$eyecatcher-height: 500px;
-$eyecatcher-height-sm: 600px;
-
 .type1-information {
   position: relative;
   .edit-activator {
@@ -91,12 +88,16 @@ $eyecatcher-height-sm: 600px;
     }
   }
 }
+
+$eyecatcher-height: 480px;
+$eyecatcher-height-sm: 600px;
+
 .eyecatcher {
   position: relative;
   height: 30vh;
   min-height: 400px;
   max-height: $eyecatcher-height;
-  min-height: calc($eyecatcher-height * 0.5);
+  min-height: calc($eyecatcher-height * 0.6);
   &__titles {
     position: absolute;
     top: 50%;

--- a/components/publish/home/type1/information.vue
+++ b/components/publish/home/type1/information.vue
@@ -25,7 +25,8 @@ await onLoad()
           place="section"
           :title="informationRef?.title"
           :subtitle="informationRef?.subtitle"
-          class="eyecatcher__titles"
+          text-no-wrap
+          class="g-block-lg eyecatcher__titles"
         />
         <div
           v-if="canEdit && informationRef?.image?.settings"
@@ -37,7 +38,12 @@ await onLoad()
           />
         </div>
       </CommonEyecatchImage>
-      <CommonContentCardBody>
+      <CommonContentCardTitle
+        :title="informationRef?.title ?? ''"
+        :subtitle="informationRef?.subtitle"
+        class="g-block-sm"
+      />
+      <CommonContentCardBody class="type1-information__body">
         <div v-if="informationRef?.body">
           <CommonWysiwsgViewer :value="informationRef?.body" />
           <div class="inquire-activator">
@@ -90,14 +96,13 @@ await onLoad()
 }
 
 $eyecatcher-height: 480px;
-$eyecatcher-height-sm: 600px;
+$eyecatcher-height-sm: 300px;
 
 .eyecatcher {
   position: relative;
   height: 30vh;
-  min-height: 400px;
   max-height: $eyecatcher-height;
-  min-height: calc($eyecatcher-height * 0.6);
+  min-height: calc($eyecatcher-height * 0.7);
   &__titles {
     position: absolute;
     top: 50%;
@@ -110,8 +115,14 @@ $eyecatcher-height-sm: 600px;
   }
 }
 @media only screen and (max-width: $grid-breakpoint-md) {
+  .type1-information {
+    &__body {
+      padding-top: 0;
+    }
+  }
+
   .eyecatcher {
-    height: 50vh;
+    height: 50vw;
     max-height: $eyecatcher-height-sm;
     min-height: calc($eyecatcher-height-sm * 0.5);
     .image-settings {

--- a/components/publish/home/type1/section-title.vue
+++ b/components/publish/home/type1/section-title.vue
@@ -9,12 +9,13 @@ const { title = '' } = defineProps<{ title?: string }>()
 </template>
 
 <style scoped lang="scss">
-.section-title {
+h3.section-title {
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
   text-align: center;
   span {
     background: linear-gradient(transparent 75%, orange 75%);
+    font-size: 1.25rem;
     font-weight: bold;
   }
 }

--- a/components/publish/news/detail.vue
+++ b/components/publish/news/detail.vue
@@ -33,6 +33,7 @@ await onLoad(contentId)
           <CommonEyecatchTitles
             place="section"
             :title="newsRef?.title"
+            :title-background-tranparent="0.5"
             class="eyecatcher__titles"
           />
           <div
@@ -128,14 +129,14 @@ await onLoad(contentId)
   }
 }
 
-$eyecatcher-height: 400px;
+$eyecatcher-height: 480px;
 $eyecatcher-height-sm: 400px;
 
 .eyecatcher {
   position: relative;
-  height: 25vh;
+  height: 30vh;
   max-height: $eyecatcher-height;
-  min-height: calc($eyecatcher-height * 0.5);
+  min-height: calc($eyecatcher-height * 0.6);
   &__titles {
     position: absolute;
     top: 50%;

--- a/components/publish/news/detail.vue
+++ b/components/publish/news/detail.vue
@@ -24,6 +24,10 @@ await onLoad(contentId)
   <CommonContentWrap :loading="loading">
     <CommonContentCard class="news-detail">
       <template #default>
+        <CommonContentCardTitle
+          :title="newsRef?.title ?? ''"
+          class="g-block-sm"
+        />
         <CommonEyecatchImage
           v-if="newsRef?.image"
           :url="newsRef?.image?.url"
@@ -33,8 +37,8 @@ await onLoad(contentId)
           <CommonEyecatchTitles
             place="section"
             :title="newsRef?.title"
-            :title-background-tranparent="0.5"
-            class="eyecatcher__titles"
+            :title-background-tranparent="0.4"
+            class="g-block-lg eyecatcher__titles"
           />
           <div
             v-if="canEdit && newsRef?.image?.settings"
@@ -46,6 +50,11 @@ await onLoad(contentId)
             />
           </div>
         </CommonEyecatchImage>
+        <CommonContentCardTitle
+          v-else
+          :title="newsRef?.title ?? ''"
+          class="g-block-lg"
+        />
         <div class="nav-pre-next-link">
           <div v-if="newsPreNextIdRefRef?.preId" class="nav-pre">
             <nuxt-link :to="`/news/${newsPreNextIdRefRef.preId}`">
@@ -60,8 +69,8 @@ await onLoad(contentId)
           </div>
           <div v-else />
         </div>
-        <CommonContentCardBody>
-          <div v-if="newsRef?.id" class="news-detail__header">
+        <CommonContentCardBody class="news-detail__body">
+          <div v-if="newsRef?.id" class="news-detail__body--header">
             <PublishNewsCategoryBadge :category="newsRef.category" small />
             <p>
               <small>{{
@@ -69,10 +78,7 @@ await onLoad(contentId)
               }}</small>
             </p>
           </div>
-          <h5 v-if="!newsRef?.image" class="g-text-cl news-detail__title">
-            <span>{{ newsRef?.title ?? '' }}</span>
-          </h5>
-          <div v-if="newsRef?.body" class="news-detail__body">
+          <div v-if="newsRef?.body" class="news-detail__body--body">
             <CommonWysiwsgViewer :value="newsRef?.body" />
           </div>
           <div v-else class="no-items">
@@ -105,12 +111,17 @@ await onLoad(contentId)
     justify-content: space-between;
     align-items: center;
   }
-  &__title {
-    font-size: 1.3rem;
-    font-weight: bold;
-  }
   &__body {
-    margin-top: 1.4rem;
+    padding-top: 0;
+    padding-bottom: 3rem;
+    &--header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    &--body {
+      margin-top: 1.4rem;
+    }
   }
   .edit-activator {
     position: absolute;
@@ -130,7 +141,7 @@ await onLoad(contentId)
 }
 
 $eyecatcher-height: 480px;
-$eyecatcher-height-sm: 400px;
+$eyecatcher-height-sm: 300px;
 
 .eyecatcher {
   position: relative;
@@ -157,21 +168,16 @@ $eyecatcher-height-sm: 400px;
 
 @media only screen and (max-width: $grid-breakpoint-md) {
   .eyecatcher {
-    height: 30vh;
+    height: 30vw;
     max-height: $eyecatcher-height-sm;
     min-height: calc($eyecatcher-height-sm * 0.5);
     .image-settings {
-      bottom: 0.5rem;
+      bottom: 0.2rem;
       right: 0.5rem;
     }
   }
   .nav-pre-next-link {
     margin-bottom: 1.5rem;
   }
-}
-
-:deep(.contents-card-body) {
-  padding-top: 0;
-  padding-bottom: 3rem;
 }
 </style>

--- a/components/publish/services/detail.vue
+++ b/components/publish/services/detail.vue
@@ -26,6 +26,10 @@ const bodyPlainString = computed(() => {
   <CommonContentWrap :loading="loading">
     <CommonContentCard class="service-detail">
       <template #default>
+        <CommonContentCardTitle
+          :title="serviceRef?.title ?? ''"
+          class="g-block-sm"
+        />
         <CommonEyecatchImage
           v-if="serviceRef?.image"
           :url="serviceRef?.image?.url"
@@ -35,8 +39,8 @@ const bodyPlainString = computed(() => {
           <CommonEyecatchTitles
             place="section"
             :title="serviceRef?.title"
-            :title-background-tranparent="0.5"
-            class="eyecatcher__titles"
+            :title-background-tranparent="0.4"
+            class="g-block-lg eyecatcher__titles"
           />
           <div
             v-if="canEdit && serviceRef?.image?.settings"
@@ -83,11 +87,6 @@ const bodyPlainString = computed(() => {
 <style scoped lang="scss">
 .service-detail {
   position: relative;
-  &__title {
-    font-size: 1.5rem;
-    font-weight: bold;
-    margin-bottom: 1.8rem;
-  }
   .edit-activator {
     position: absolute;
     top: 1rem;
@@ -106,7 +105,7 @@ const bodyPlainString = computed(() => {
 }
 
 $eyecatcher-height: 480px;
-$eyecatcher-height-sm: 400px;
+$eyecatcher-height-sm: 300px;
 
 .eyecatcher {
   position: relative;
@@ -127,11 +126,11 @@ $eyecatcher-height-sm: 400px;
 
 @media only screen and (max-width: $grid-breakpoint-md) {
   .eyecatcher {
-    height: 30vh;
+    height: 30vw;
     max-height: $eyecatcher-height-sm;
     min-height: calc($eyecatcher-height-sm * 0.5);
     .image-settings {
-      bottom: 0.5rem;
+      bottom: 0.2rem;
       right: 0.5rem;
     }
   }

--- a/components/publish/services/detail.vue
+++ b/components/publish/services/detail.vue
@@ -35,6 +35,7 @@ const bodyPlainString = computed(() => {
           <CommonEyecatchTitles
             place="section"
             :title="serviceRef?.title"
+            :title-background-tranparent="0.5"
             class="eyecatcher__titles"
           />
           <div
@@ -104,14 +105,14 @@ const bodyPlainString = computed(() => {
   }
 }
 
-$eyecatcher-height: 400px;
+$eyecatcher-height: 480px;
 $eyecatcher-height-sm: 400px;
 
 .eyecatcher {
   position: relative;
-  height: 25vh;
+  height: 30vh;
   max-height: $eyecatcher-height;
-  min-height: calc($eyecatcher-height * 0.5);
+  min-height: calc($eyecatcher-height * 0.6);
   &__titles {
     position: absolute;
     top: 50%;

--- a/prod-docker-compose-frontend.yml
+++ b/prod-docker-compose-frontend.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: Dockerfile
       args:
         - VITE_BACKEND_BASEURL=${VITE_BACKEND_BASEURL}
-    image: ngzm/iine-frontend:1.0.22
+    image: ngzm/iine-frontend:1.0.23
     tty: true
     stdin_open: true
     ports:


### PR DESCRIPTION
主にタイトルの表示方法・位置についてスマホの場合は、アイキャッチ画像に入れるのではなくその前後に表示するように修正した。

また、PC向け画面も少々デザインについて間合いや高さなどの微調整を実施。