### PR TITLE
ImageData Type に file.name と file.type のデータを保存できるように修正

### DIFF
--- a/components/base/file/input-image.vue
+++ b/components/base/file/input-image.vue
@@ -55,17 +55,15 @@ const invalidMessages = computed<string[] | null>(() =>
 )
 
 const imageSrc = computed(() => {
-  // TODO: nagazumi
-  // props.imageType が BE含めてきちんと実装できたら
-  // 下記の式はもう一度きちんと再実装すること
   if (!props.imageUrl) {
     return '/images/no-image.jpg'
   }
   if (!props.imageType) {
     return props.imageUrl?.length ? props.imageUrl : '/images/no-image.jpg'
   }
-  return getAccesstableImageTypes().includes(props.imageType) &&
-    props.imageUrl?.length
+  return (props.accessables || getAccesstableImageTypes()).includes(
+    props.imageType
+  ) && props.imageUrl?.length
     ? props.imageUrl
     : '/images/no-image.jpg'
 })

--- a/components/common/content-input-image.vue
+++ b/components/common/content-input-image.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
+import type { ImageSettings } from '@/types/content'
+
 const imageUrl = defineModel<string>('url')
 const imageName = defineModel<string>('name')
 const imageType = defineModel<string>('type')
+const imageSetting = defineModel<ImageSettings | null>('settings')
+
 const props = defineProps<{
   label?: string
   errorMessages?: string | string[]
@@ -25,6 +29,7 @@ const onChangeImageFile = async (imageFile: File) => {
   imageUrl.value = response.fileUrl
   imageName.value = imageFile.name
   imageType.value = imageFile.type
+  imageSetting.value = null
 }
 const isLoading = computed(
   () => compressing.value || inputBodyImagePosting.value

--- a/components/manage/content/contact.vue
+++ b/components/manage/content/contact.vue
@@ -69,6 +69,7 @@ const onCancel = () => {
           v-model:url="formData.image.value.value"
           v-model:name="formData.imageName.value.value"
           v-model:type="formData.imageType.value.value"
+          v-model:settings="formData.imageSettings.value.value"
           :error-messages="formData.image.errorMessage.value"
           label="タイトル画像"
           :customer-id="customerId"

--- a/components/manage/content/eyecatcher.vue
+++ b/components/manage/content/eyecatcher.vue
@@ -72,6 +72,7 @@ const onCancel = () => {
           v-model:url="formData.image.value.value"
           v-model:name="formData.imageName.value.value"
           v-model:type="formData.imageType.value.value"
+          v-model:settings="formData.imageSettings.value.value"
           :error-messages="formData.image.errorMessage.value"
           label="トップ画像"
           :customer-id="customerId"

--- a/components/manage/content/information.vue
+++ b/components/manage/content/information.vue
@@ -71,6 +71,7 @@ const onCancel = () => {
           v-model:url="formData.image.value.value"
           v-model:name="formData.imageName.value.value"
           v-model:type="formData.imageType.value.value"
+          v-model:settings="formData.imageSettings.value.value"
           :error-messages="formData.image.errorMessage.value"
           label="タイトル画像"
           :customer-id="customerId"

--- a/components/manage/content/menu-image.vue
+++ b/components/manage/content/menu-image.vue
@@ -78,6 +78,7 @@ const onCancel = () => {
           v-model:url="formData.image.value.value"
           v-model:name="formData.imageName.value.value"
           v-model:type="formData.imageType.value.value"
+          v-model:settings="formData.imageSettings.value.value"
           :error-messages="formData.image.errorMessage.value"
           label="タイトル画像"
           :customer-id="customerId"

--- a/components/manage/content/news.vue
+++ b/components/manage/content/news.vue
@@ -77,6 +77,7 @@ const onCancel = () => {
           v-model:url="formData.image.value.value"
           v-model:name="formData.imageName.value.value"
           v-model:type="formData.imageType.value.value"
+          v-model:settings="formData.imageSettings.value.value"
           :error-messages="formData.image.errorMessage.value"
           label="タイトル画像"
           :customer-id="customerId"

--- a/components/manage/content/service-body.vue
+++ b/components/manage/content/service-body.vue
@@ -70,6 +70,7 @@ const onCancel = () => {
           v-model:url="formData.image.value.value"
           v-model:name="formData.imageName.value.value"
           v-model:type="formData.imageType.value.value"
+          v-model:settings="formData.imageSettings.value.value"
           :error-messages="formData.image.errorMessage.value"
           label="タイトル画像"
           :customer-id="customerId"

--- a/components/manage/content/service.vue
+++ b/components/manage/content/service.vue
@@ -70,6 +70,7 @@ const onCancel = () => {
           v-model:url="formData.image.value.value"
           v-model:name="formData.imageName.value.value"
           v-model:type="formData.imageType.value.value"
+          v-model:settings="formData.imageSettings.value.value"
           :error-messages="formData.image.errorMessage.value"
           label="タイトル画像"
           :customer-id="customerId"

--- a/composables/use-content/use-base-content.ts
+++ b/composables/use-content/use-base-content.ts
@@ -227,8 +227,7 @@ export const useContentRead = <T extends ContentGetApi>(
     if (!contentDataRef.value) return
     if (!contentDataRef.value.image?.settings) return
 
-    const url = contentDataRef.value.image.url
-    contentDataRef.value.image = { url, settings }
+    contentDataRef.value.image.settings = { ...settings }
   }
 
   return {

--- a/composables/use-content/use-contact-form.ts
+++ b/composables/use-content/use-contact-form.ts
@@ -22,6 +22,7 @@ export const useContactForm = () => {
     image: () => true,
     imageName: () => true,
     imageType: () => true,
+    imageSettings: () => true,
   }
   const contactFormInitial: ContactForm = {
     title: '',
@@ -30,6 +31,7 @@ export const useContactForm = () => {
     image: '',
     imageName: '',
     imageType: '',
+    imageSettings: null,
   }
 
   const { handleSubmit, handleReset, validate } = useForm({
@@ -44,14 +46,18 @@ export const useContactForm = () => {
     image: useField<ContactForm['image']>('image'),
     imageName: useField<ContactForm['imageName']>('imageName'),
     imageType: useField<ContactForm['imageType']>('imageType'),
+    imageSettings: useField<ContactForm['imageSettings']>('imageSettings'),
   }
 
   const resetContactForm = (contactData?: ContactType | null) => {
     if (!contactData) return
-    formData.title.value.value = contactData?.title ?? ''
-    formData.subtitle.value.value = contactData?.subtitle ?? ''
-    formData.body.value.value = contactData?.body ?? ''
-    formData.image.value.value = contactData?.image?.url ?? ''
+    formData.title.value.value = contactData.title ?? ''
+    formData.subtitle.value.value = contactData.subtitle ?? ''
+    formData.body.value.value = contactData.body ?? ''
+    formData.image.value.value = contactData.image?.url ?? ''
+    formData.imageName.value.value = contactData.image?.name ?? ''
+    formData.imageType.value.value = contactData.image?.type ?? ''
+    formData.imageSettings.value.value = contactData.image?.settings ?? null
   }
 
   return {

--- a/composables/use-content/use-eyecatch-form.ts
+++ b/composables/use-content/use-eyecatch-form.ts
@@ -18,6 +18,7 @@ export const useEyecatchForm = () => {
       noBlank(v) || 'トップ背景画像ファイルを設定してください',
     imageName: () => true,
     imageType: () => true,
+    imageSettings: () => true,
   }
   const eyecatchFormInitial: EyecatchForm = {
     title: '',
@@ -25,6 +26,7 @@ export const useEyecatchForm = () => {
     image: '',
     imageName: '',
     imageType: '',
+    imageSettings: null,
   }
 
   const { handleSubmit, handleReset, validate } = useForm({
@@ -38,13 +40,17 @@ export const useEyecatchForm = () => {
     image: useField<EyecatchForm['image']>('image'),
     imageName: useField<EyecatchForm['imageName']>('imageName'),
     imageType: useField<EyecatchForm['imageType']>('imageType'),
+    imageSettings: useField<EyecatchForm['imageSettings']>('imageSettings'),
   }
 
   const resetEyeCatchForm = (eyecatchData?: EyecatchType | null) => {
     if (!eyecatchData) return
-    formData.title.value.value = eyecatchData?.title ?? ''
-    formData.subtitle.value.value = eyecatchData?.subtitle ?? ''
-    formData.image.value.value = eyecatchData?.image?.url ?? ''
+    formData.title.value.value = eyecatchData.title
+    formData.subtitle.value.value = eyecatchData.subtitle ?? ''
+    formData.image.value.value = eyecatchData.image.url
+    formData.imageName.value.value = eyecatchData.image.name
+    formData.imageType.value.value = eyecatchData.image.type
+    formData.imageSettings.value.value = eyecatchData.image.settings ?? null
   }
 
   return {

--- a/composables/use-content/use-eyecatch.ts
+++ b/composables/use-content/use-eyecatch.ts
@@ -30,13 +30,50 @@ const useEyecatchContent = (customerId: Ref<number | null>) => {
           customerId: apiData.customerId,
           title: apiData.title,
           subtitle: apiData.subtitle,
-          image: apiData.image,
+          image: {
+            url: apiData.image.url,
+            name: apiData.image.name ?? 'dummy_name',
+            type:
+              apiData.image.type ??
+              getFileTypeByExtention(getFileExtension(apiData.image.url)),
+            settings: apiData.image.settings,
+          },
         }
       : null
+
   const eyecatchRef = computed<EyecatchType | null>(() =>
     apitypeToEyecatchType(contentDataRef.value)
   )
   const loading = computed(() => readLoading.value || writeLoading.value)
+
+  const formToEyecatchSaveApi = (formData: EyecatchForm): EyecatchSaveApi => ({
+    customerId: customerId.value ?? 0,
+    title: formData.title,
+    subtitle: formData.subtitle,
+    image: {
+      url: formData.image,
+      name: formData.imageName,
+      type: formData.imageType,
+      settings: formData.imageSettings ?? getDefaultImageSettings(),
+    },
+  })
+
+  const createEyecatch = async (
+    formData: EyecatchForm
+  ): Promise<EyecatchType | null> => {
+    const inputData: EyecatchSaveApi = formToEyecatchSaveApi(formData)
+    const data = await create(inputData)
+    return apitypeToEyecatchType(data ?? null)
+  }
+
+  const updateEyecatch = async (
+    contentId: number,
+    formData: EyecatchForm
+  ): Promise<EyecatchType | null> => {
+    const inputData: EyecatchSaveApi = formToEyecatchSaveApi(formData)
+    const data = await update(contentId, inputData)
+    return apitypeToEyecatchType(data ?? null)
+  }
 
   const setEyecatchImageSettings = (settings: Partial<ImageSettings>) => {
     if (!eyecatchRef.value) return
@@ -50,50 +87,13 @@ const useEyecatchContent = (customerId: Ref<number | null>) => {
     return newSettings
   }
 
-  const createEyecatch = async (
-    formData: EyecatchForm
-  ): Promise<EyecatchType | null> => {
-    const inputData: EyecatchSaveApi = {
-      customerId: customerId.value ?? 0,
-      title: formData.title,
-      subtitle: formData.subtitle,
-      image: {
-        url: formData.image,
-        settings: getDefaultImageSettings(),
-      },
-    }
-    const data = await create(inputData)
-    return apitypeToEyecatchType(data ?? null)
-  }
-
-  const updateEyecatch = async (
-    contentId: number,
-    formData: EyecatchForm
-  ): Promise<EyecatchType | null> => {
-    const settings =
-      formData.image === eyecatchRef.value?.image?.url
-        ? eyecatchRef.value?.image?.settings
-        : getDefaultImageSettings()
-    const inputData: EyecatchSaveApi = {
-      customerId: customerId.value ?? 0,
-      title: formData.title,
-      subtitle: formData.subtitle,
-      image: {
-        url: formData.image,
-        settings,
-      },
-    }
-    const data = await update(contentId, inputData)
-    return apitypeToEyecatchType(data ?? null)
-  }
-
   return {
     loadEyecatch: loadData,
     getEyecatch: get,
-    setEyecatchImageSettings,
     createEyecatch,
     updateEyecatch,
     removeEyecatch: remove,
+    setEyecatchImageSettings,
     updateEyecatchImageSettings: updateImageSettingsWithDebounced,
     eyecatchRef,
     loading,

--- a/composables/use-content/use-information-form.ts
+++ b/composables/use-content/use-information-form.ts
@@ -22,6 +22,7 @@ export const useInformationForm = () => {
     image: () => true,
     imageName: () => true,
     imageType: () => true,
+    imageSettings: () => true,
   }
   const informationFormInitial: InformationForm = {
     title: '',
@@ -30,6 +31,7 @@ export const useInformationForm = () => {
     image: '',
     imageName: '',
     imageType: '',
+    imageSettings: null,
   }
 
   const { handleSubmit, handleReset, validate } = useForm({
@@ -44,14 +46,18 @@ export const useInformationForm = () => {
     image: useField<InformationForm['image']>('image'),
     imageName: useField<InformationForm['imageName']>('imageName'),
     imageType: useField<InformationForm['imageType']>('imageType'),
+    imageSettings: useField<InformationForm['imageSettings']>('imageSettings'),
   }
 
   const resetInformationForm = (informationData?: InformationType | null) => {
     if (!informationData) return
-    formData.title.value.value = informationData?.title ?? ''
-    formData.subtitle.value.value = informationData?.subtitle ?? ''
-    formData.body.value.value = informationData?.body ?? ''
-    formData.image.value.value = informationData?.image?.url ?? ''
+    formData.title.value.value = informationData.title ?? ''
+    formData.subtitle.value.value = informationData.subtitle ?? ''
+    formData.body.value.value = informationData.body ?? ''
+    formData.image.value.value = informationData.image?.url ?? ''
+    formData.imageName.value.value = informationData.image?.name ?? ''
+    formData.imageType.value.value = informationData.image?.type ?? ''
+    formData.imageSettings.value.value = informationData.image?.settings ?? null
   }
 
   return {

--- a/composables/use-content/use-menu-image-form.ts
+++ b/composables/use-content/use-menu-image-form.ts
@@ -22,6 +22,7 @@ export const useMenuImageForm = () => {
       noBlank(v) || 'タイトル画像ファイルを設定してください',
     imageName: () => true,
     imageType: () => true,
+    imageSettings: () => true,
     position: () => true,
     menuImageUrl: (v: string | undefined) =>
       noBlank(v) || 'メニュー用ファイルを設定してください',
@@ -34,6 +35,7 @@ export const useMenuImageForm = () => {
     image: '',
     imageName: '',
     imageType: '',
+    imageSettings: null,
     position: 0,
     menuImageUrl: '',
     menuImageName: '',
@@ -51,6 +53,7 @@ export const useMenuImageForm = () => {
     image: useField<MenuImageForm['image']>('image'),
     imageName: useField<MenuImageForm['imageName']>('imageName'),
     imageType: useField<MenuImageForm['imageType']>('imageType'),
+    imageSettings: useField<MenuImageForm['imageSettings']>('imageSettings'),
     position: useField<MenuImageForm['position']>('position'),
     menuImageUrl: useField<MenuImageForm['menuImageUrl']>('menuImageUrl'),
     menuImageName: useField<MenuImageForm['menuImageName']>('menuImageName'),
@@ -62,6 +65,9 @@ export const useMenuImageForm = () => {
     formData.title.value.value = menuImageData.title ?? ''
     formData.caption.value.value = menuImageData.caption ?? ''
     formData.image.value.value = menuImageData.image?.url ?? ''
+    formData.imageName.value.value = menuImageData.image?.name ?? ''
+    formData.imageType.value.value = menuImageData.image?.type ?? ''
+    formData.imageSettings.value.value = menuImageData.image?.settings ?? null
     formData.position.value.value = menuImageData.position ?? 0
     formData.menuImageUrl.value.value = menuImageData.menuImage.url ?? ''
     formData.menuImageName.value.value = menuImageData.menuImage.name ?? ''

--- a/composables/use-content/use-menu-image.ts
+++ b/composables/use-content/use-menu-image.ts
@@ -46,40 +46,22 @@ const useMenuImageContent = (customerId: Ref<number | null>) => {
           customerId: apiData.customerId,
           title: apiData.title,
           caption: apiData.caption,
-          image: apiData.image,
+          image: {
+            url: apiData.image.url,
+            name: apiData.image.name ?? 'dummy_name',
+            type:
+              apiData.image.type ??
+              getFileTypeByExtention(getFileExtension(apiData.image.url)),
+            settings: apiData.image.settings,
+          },
           position: apiData.position,
           menuImage: {
-            name: apiData.menuImage?.name ?? '',
-            type: apiData.menuImage?.type ?? '',
-            url: apiData.menuImage?.url ?? '',
+            name: apiData.menuImage.name,
+            type: apiData.menuImage.type,
+            url: apiData.menuImage.url,
           },
         }
       : null
-
-  const formToMenuImageSaveApi = (
-    formData: MenuImageForm
-  ): MenuImageSaveApi => {
-    const settings =
-      formData.image === menuImageRef.value?.image?.url
-        ? menuImageRef.value?.image?.settings
-        : getDefaultImageSettings()
-    return {
-      customerId: customerId.value ?? 0,
-      title: formData.title,
-      caption: formData.caption,
-      body: formData.body,
-      position: formData.position,
-      image: {
-        url: formData.image,
-        settings,
-      },
-      menuImage: {
-        url: formData.menuImageUrl,
-        name: formData.menuImageName,
-        type: formData.menuImageType,
-      },
-    }
-  }
 
   const menuImageRef = computed<MenuImageType | null>(() =>
     apiToMenuImageType(contentDataRef.value)
@@ -95,16 +77,26 @@ const useMenuImageContent = (customerId: Ref<number | null>) => {
   )
   const loading = computed(() => readLoading.value || writeLoading.value)
 
-  const setMenuImageListPositions = (
-    menuImageList: MenuImageType[]
-  ): ContentPosition[] => {
-    const positions = menuImageList.map<ContentPositionApi>((d, i) => ({
-      id: d.id,
-      position: i + 1,
-    }))
-    setListPositions(positions)
-    return positions
-  }
+  const formToMenuImageSaveApi = (
+    formData: MenuImageForm
+  ): MenuImageSaveApi => ({
+    customerId: customerId.value ?? 0,
+    title: formData.title,
+    caption: formData.caption,
+    body: formData.body,
+    position: formData.position,
+    image: {
+      url: formData.image,
+      name: formData.imageName,
+      type: formData.imageType,
+      settings: formData.imageSettings ?? getDefaultImageSettings(),
+    },
+    menuImage: {
+      url: formData.menuImageUrl,
+      name: formData.menuImageName,
+      type: formData.menuImageType,
+    },
+  })
 
   const createMenuImage = async (
     formData: MenuImageForm
@@ -119,6 +111,17 @@ const useMenuImageContent = (customerId: Ref<number | null>) => {
   ): Promise<MenuImageType | null> => {
     const data = await update(contentId, formToMenuImageSaveApi(formData))
     return apiToMenuImageType(data ?? null)
+  }
+
+  const setMenuImageListPositions = (
+    menuImageList: MenuImageType[]
+  ): ContentPosition[] => {
+    const positions = menuImageList.map<ContentPositionApi>((d, i) => ({
+      id: d.id,
+      position: i + 1,
+    }))
+    setListPositions(positions)
+    return positions
   }
 
   return {

--- a/composables/use-content/use-news-form.ts
+++ b/composables/use-content/use-news-form.ts
@@ -19,6 +19,7 @@ export const useNewsForm = () => {
     image: () => true,
     imageName: () => true,
     imageType: () => true,
+    imageSettings: () => true,
   }
   const newsFormInitial: NewsForm = {
     title: '',
@@ -28,6 +29,7 @@ export const useNewsForm = () => {
     image: '',
     imageName: '',
     imageType: '',
+    imageSettings: null,
   }
 
   const { handleSubmit, handleReset, validate } = useForm({
@@ -43,15 +45,19 @@ export const useNewsForm = () => {
     image: useField<NewsForm['image']>('image'),
     imageName: useField<NewsForm['imageName']>('imageName'),
     imageType: useField<NewsForm['imageType']>('imageType'),
+    imageSettings: useField<NewsForm['imageSettings']>('imageSettings'),
   }
 
   const resetNewsForm = (newsData?: NewsType | null) => {
     if (!newsData) return
-    formData.title.value.value = newsData?.title ?? ''
-    formData.category.value.value = newsData?.category ?? null
-    formData.publishOn.value.value = newsData?.publishOn ?? null
-    formData.body.value.value = newsData?.body ?? ''
-    formData.image.value.value = newsData?.image?.url ?? ''
+    formData.title.value.value = newsData.title ?? ''
+    formData.category.value.value = newsData.category ?? null
+    formData.publishOn.value.value = newsData.publishOn ?? null
+    formData.body.value.value = newsData.body ?? ''
+    formData.image.value.value = newsData.image?.url ?? ''
+    formData.imageName.value.value = newsData.image?.name ?? ''
+    formData.imageType.value.value = newsData.image?.type ?? ''
+    formData.imageSettings.value.value = newsData.image?.settings ?? null
   }
 
   return {

--- a/composables/use-content/use-service-form.ts
+++ b/composables/use-content/use-service-form.ts
@@ -22,6 +22,7 @@ export const useServiceForm = () => {
       noBlank(v) || 'タイトル画像ファイルを設定してください',
     imageName: () => true,
     imageType: () => true,
+    imageSettings: () => true,
     body: () => true,
     position: () => true,
   }
@@ -32,6 +33,7 @@ export const useServiceForm = () => {
     image: '',
     imageName: '',
     imageType: '',
+    imageSettings: null,
     position: 0,
   }
 
@@ -47,6 +49,7 @@ export const useServiceForm = () => {
     image: useField<ServiceForm['image']>('image'),
     imageName: useField<ServiceForm['imageName']>('imageName'),
     imageType: useField<ServiceForm['imageType']>('imageType'),
+    imageSettings: useField<ServiceForm['imageSettings']>('imageSettings'),
     position: useField<ServiceForm['position']>('position'),
   }
 
@@ -56,6 +59,9 @@ export const useServiceForm = () => {
     formData.caption.value.value = serviceData?.caption ?? ''
     formData.body.value.value = serviceData?.body ?? ''
     formData.image.value.value = serviceData?.image?.url ?? ''
+    formData.imageName.value.value = serviceData?.image?.name ?? ''
+    formData.imageType.value.value = serviceData?.image?.type ?? ''
+    formData.imageSettings.value.value = serviceData?.image?.settings ?? null
     formData.position.value.value = serviceData?.position ?? 0
   }
 

--- a/composables/use-content/use-service.ts
+++ b/composables/use-content/use-service.ts
@@ -49,7 +49,14 @@ const useServiceContent = (customerId: Ref<number | null>) => {
           title: apiData.title,
           caption: apiData.caption,
           body: apiData.body,
-          image: apiData.image,
+          image: {
+            url: apiData.image.url,
+            name: apiData.image.name ?? 'dummy_name',
+            type:
+              apiData.image.type ??
+              getFileTypeByExtention(getFileExtension(apiData.image.url)),
+            settings: apiData.image.settings,
+          },
           position: apiData.position,
         }
       : null
@@ -67,6 +74,37 @@ const useServiceContent = (customerId: Ref<number | null>) => {
     () => contentListRef.value?.total ?? null
   )
   const loading = computed(() => readLoading.value || writeLoading.value)
+
+  const formToServiceSaveApi = (formData: ServiceForm): ServiceSaveApi => ({
+    customerId: customerId.value ?? 0,
+    title: formData.title,
+    caption: formData.caption,
+    body: formData.body,
+    position: formData.position,
+    image: {
+      url: formData.image,
+      name: formData.imageName,
+      type: formData.imageType,
+      settings: formData.imageSettings ?? getDefaultImageSettings(),
+    },
+  })
+
+  const createService = async (
+    formData: ServiceForm
+  ): Promise<ServiceType | null> => {
+    const inputData: ServiceSaveApi = formToServiceSaveApi(formData)
+    const data = await create(inputData)
+    return apitypeToServiceType(data ?? null)
+  }
+
+  const updateService = async (
+    contentId: number,
+    formData: ServiceForm
+  ): Promise<ServiceType | null> => {
+    const inputData: ServiceSaveApi = formToServiceSaveApi(formData)
+    const data = await update(contentId, inputData)
+    return apitypeToServiceType(data ?? null)
+  }
 
   const setServiceImageSettings = (
     settings: Partial<ImageSettings>
@@ -91,47 +129,6 @@ const useServiceContent = (customerId: Ref<number | null>) => {
     }))
     setListPositions(positions)
     return positions
-  }
-
-  const createService = async (
-    formData: ServiceForm
-  ): Promise<ServiceType | null> => {
-    const inputData: ServiceSaveApi = {
-      customerId: customerId.value ?? 0,
-      title: formData.title,
-      caption: formData.caption,
-      body: formData.body,
-      position: formData.position,
-      image: {
-        url: formData.image,
-        settings: getDefaultImageSettings(),
-      },
-    }
-    const data = await create(inputData)
-    return apitypeToServiceType(data ?? null)
-  }
-
-  const updateService = async (
-    contentId: number,
-    formData: ServiceForm
-  ): Promise<ServiceType | null> => {
-    const settings =
-      formData.image === serviceRef.value?.image?.url
-        ? serviceRef.value?.image?.settings
-        : getDefaultImageSettings()
-    const inputData: ServiceSaveApi = {
-      customerId: customerId.value ?? 0,
-      title: formData.title,
-      caption: formData.caption,
-      body: formData.body,
-      position: formData.position,
-      image: {
-        url: formData.image,
-        settings,
-      },
-    }
-    const data = await update(contentId, inputData)
-    return apitypeToServiceType(data ?? null)
   }
 
   return {

--- a/composables/use-file.ts
+++ b/composables/use-file.ts
@@ -53,37 +53,3 @@ export const useFilePost = (customerId: Ref<number | null>, kind: string) => {
     loading,
   }
 }
-
-const acceptableImageExtensions = [
-  'jpg',
-  'JPG',
-  'jpeg',
-  'jpeg',
-  'png',
-  'PNG',
-  'gif',
-  '.webp',
-]
-export const getAccesstableImageExtensions = () => acceptableImageExtensions
-export const isImageFileByExt = (file: File) => {
-  const ext = file.name.split('.').pop() ?? 'bad-file'
-  return acceptableImageExtensions.includes(ext)
-}
-
-const accesstableImageTypes = [
-  'image/jpeg',
-  'image/png',
-  'image/gif',
-  'image/webp',
-]
-export const getAccesstableImageTypes = () => accesstableImageTypes
-export const isImageFileByType = (file: File) => {
-  const type = file.type
-  return accesstableImageTypes.includes(type)
-}
-
-export const isImageFile = (file: File) =>
-  isImageFileByType(file) || isImageFileByExt(file)
-
-const accessiblePdfTypes = ['application/pdf']
-export const getAccesstablePdfTypes = () => accessiblePdfTypes

--- a/types/API/content-api.d.ts
+++ b/types/API/content-api.d.ts
@@ -20,7 +20,6 @@ export interface ContentGetApi {
 }
 
 export interface EyecatchGetApi extends ContentGetApi {
-  subtitle: string
   image: ImageData
 }
 export interface InformationGetApi extends ContentGetApi {
@@ -59,7 +58,6 @@ export type ContentSaveApi = {
 
 export interface EyecatchSaveApi extends ContentSaveApi {
   image: ImageData
-  subtitle: string
 }
 export interface InformationSaveApi extends ContentSaveApi {
   body: string

--- a/types/content.d.ts
+++ b/types/content.d.ts
@@ -14,8 +14,8 @@ export interface ImageSettings {
 
 export interface ImageData {
   url: string
-  type?: string
-  name?: string
+  type: string
+  name: string
   settings: ImageSettings
 }
 
@@ -72,9 +72,9 @@ export interface ContentForm {
   image?: string
   imageName?: string
   imageType?: string
+  imageSettings?: ImageSettings | null
 }
 export interface EyecatchForm extends ContentForm {
-  subtitle: string
   image: string
   imageName: string
   imageType: string

--- a/utils/misc.ts
+++ b/utils/misc.ts
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
-// import sanitizeHtml from 'sanitize-html'
 
 // Day.js set default timezone
 dayjs.extend(utc)
@@ -43,3 +42,46 @@ export const sleep = (sleepms: number) => {
     }, sleepms)
   )
 }
+
+/**
+ * FILE 関連ユーティリティ
+ */
+export const getFileExtension = (filename: string) => {
+  const extention = filename.split('.').pop() ?? 'bad-file'
+  return extention.toLowerCase()
+}
+
+const acceptableImageExtensions = ['jpg', 'jpeg', 'png', 'gif', '.webp']
+export const getAccesstableImageExtensions = () => acceptableImageExtensions
+export const isImageFileByExt = (ext: string): boolean =>
+  acceptableImageExtensions.includes(ext)
+
+const accesstableImageTypes = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]
+export const getAccesstableImageTypes = () => accesstableImageTypes
+export const isImageFileByType = (type: string): boolean =>
+  accesstableImageTypes.includes(type)
+
+export const isImageFile = (file: File): boolean => {
+  const ext = getFileExtension(file.name)
+  const type = file.type
+  return isImageFileByType(type) || isImageFileByExt(ext)
+}
+
+const accessiblePdfTypes = ['application/pdf']
+export const getAccesstablePdfTypes = () => accessiblePdfTypes
+
+const fileExtention2Type: { [k: string]: string } = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  pdf: 'application/pdf',
+}
+export const getFileTypeByExtention = (ext: string) =>
+  fileExtention2Type[ext] ?? 'application/octet-stream'


### PR DESCRIPTION
ImageData Type に file.name と file.type のデータを保存できるように修正しました。

また、image settings の情報も form でも持ち回り、UIで画像が設定されたときに初めてクリアされるような形に実装をしなおしました。

cf. #129