### PR TITLE
トップイメージ titleSettings スマホとPCで position 値を其々保持できるように

### DIFF
--- a/components/common/eyecatch-title-setting-position-eyecatcher.vue
+++ b/components/common/eyecatch-title-setting-position-eyecatcher.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import type { TitleSettings, EyecatchTitleSettings } from '@/types/content'
+
+const props = withDefaults(
+  defineProps<{
+    settings?: EyecatchTitleSettings | null
+    canEdit?: boolean
+  }>(),
+  {
+    settings: null,
+    canEdit: false,
+  }
+)
+const emit = defineEmits<{
+  update: [partOfSettings: Partial<EyecatchTitleSettings>]
+}>()
+
+const { isSmall, isJudged } = useMediaQueryIsSmall()
+
+const titleSettings = computed<TitleSettings | null>(() => {
+  if (!props.settings) {
+    return null
+  }
+  if (isSmall.value) {
+    return {
+      fontFamily: props.settings.fontFamily,
+      color: props.settings.color,
+      bgColor: props.settings.bgColor,
+      align: props.settings.align,
+      position: props.settings.positionSm,
+    }
+  } else {
+    return {
+      fontFamily: props.settings.fontFamily,
+      color: props.settings.color,
+      bgColor: props.settings.bgColor,
+      align: props.settings.align,
+      position: props.settings.position,
+    }
+  }
+})
+
+const onUpdateSettings = (setting: Partial<EyecatchTitleSettings>) => {
+  if (isSmall.value) {
+    emit('update', { positionSm: setting.position })
+  } else {
+    emit('update', { ...setting })
+  }
+}
+</script>
+
+<template>
+  <CommonEyecatchTitleSettingPosition
+    v-if="isJudged"
+    :settings="titleSettings"
+    :can-edit="canEdit"
+    @update="onUpdateSettings"
+  >
+    <template #default>
+      <slot />
+    </template>
+    <template v-if="$slots.topSettings" #topSettings>
+      <slot name="topSettings" />
+    </template>
+    <template v-if="$slots.sideSettings" #sideSettings>
+      <slot name="sideSettings" />
+    </template>
+  </CommonEyecatchTitleSettingPosition>
+</template>

--- a/components/common/eyecatch-title-setting-position.vue
+++ b/components/common/eyecatch-title-setting-position.vue
@@ -2,7 +2,10 @@
 import type { TitleSettings } from '@/types/content'
 
 const props = withDefaults(
-  defineProps<{ settings?: TitleSettings | null; canEdit?: boolean }>(),
+  defineProps<{
+    settings?: TitleSettings | null
+    canEdit?: boolean
+  }>(),
   {
     settings: null,
     canEdit: false,
@@ -57,24 +60,29 @@ const onUpdatePosition = (pos: { x: number; y: number }) => {
 
 <template>
   <CommonContentItemMovable
+    v-if="canEdit"
     :position="position"
-    :can-edit="canEdit"
     @update:position="onUpdatePosition"
   >
-    <div class="title-setting-position-frame">
+    <div class="eyecatch-title-setting-position-editable">
       <slot />
-      <div v-if="canEdit && $slots.topSettings" class="top-settings">
+      <div v-if="$slots.topSettings" class="top-settings">
         <slot name="topSettings" />
       </div>
-      <div v-if="canEdit && $slots.sideSettings" class="side-settings">
+      <div v-if="$slots.sideSettings" class="side-settings">
         <slot name="sideSettings" />
       </div>
     </div>
   </CommonContentItemMovable>
+  <div v-else class="eyecatch-title-setting-position">
+    <div class="eyecatch-title">
+      <slot />
+    </div>
+  </div>
 </template>
 
 <style lang="scss" scoped>
-.title-setting-position-frame {
+.eyecatch-title-setting-position-editable {
   position: relative;
 
   .top-settings {
@@ -90,6 +98,20 @@ const onUpdatePosition = (pos: { x: number; y: number }) => {
     top: -0.25rem;
     left: v-bind('settingsLeft');
     right: v-bind('settingsRight');
+  }
+}
+
+.eyecatch-title-setting-position {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+
+  .eyecatch-title {
+    position: absolute;
+    top: v-bind('`${position.y}%`');
+    left: v-bind('`${position.x}%`');
+    transform: translate(-50%, -50%);
   }
 }
 </style>

--- a/components/common/eyecatch-title.vue
+++ b/components/common/eyecatch-title.vue
@@ -85,10 +85,10 @@ const titleAlign = computed(() => props.settings?.align ?? 'left')
     font-size: 2.5rem;
 
     @media only screen and (max-width: $grid-breakpoint-lg) {
-      font-size: 2.25rem;
+      font-size: 2.2rem;
     }
     @media only screen and (max-width: $grid-breakpoint-md) {
-      font-size: 2rem;
+      font-size: 1.75rem;
     }
   }
 
@@ -102,7 +102,7 @@ const titleAlign = computed(() => props.settings?.align ?? 'left')
     }
     @media only screen and (max-width: $grid-breakpoint-md) {
       margin-top: 0.5rem;
-      font-size: 1.25rem;
+      font-size: 1.1rem;
     }
   }
 }
@@ -118,7 +118,7 @@ const titleAlign = computed(() => props.settings?.align ?? 'left')
     font-size: 1.5rem;
 
     @media only screen and (max-width: $grid-breakpoint-lg) {
-      font-size: 1.5rem;
+      font-size: 1.4rem;
     }
     @media only screen and (max-width: $grid-breakpoint-md) {
       font-size: 1.25rem;

--- a/components/publish/home/type1/contact.vue
+++ b/components/publish/home/type1/contact.vue
@@ -25,7 +25,7 @@ await onLoad()
         class="eyecatcher"
       >
         <template #default>
-          <CommonEyecatchTitleSettingPositionFrame
+          <CommonEyecatchTitleSettingPosition
             :settings="contactRef?.titleSettings"
             :can-edit="canEdit"
             class="g-block-lg"
@@ -52,7 +52,7 @@ await onLoad()
                 @update="onUpdateTitleSetting"
               />
             </template>
-          </CommonEyecatchTitleSettingPositionFrame>
+          </CommonEyecatchTitleSettingPosition>
         </template>
         <template v-if="canEdit && contactRef" #settings>
           <CommonEyecatchImageSetting

--- a/components/publish/home/type1/eyecatcher.vue
+++ b/components/publish/home/type1/eyecatcher.vue
@@ -26,7 +26,7 @@ await onLoad()
       class="eyecatcher"
     >
       <template #default>
-        <CommonEyecatchTitleSettingPositionFrame
+        <CommonEyecatchTitleSettingPositionEyecatcher
           :settings="eyecatchRef?.titleSettings"
           :can-edit="canEdit"
           @update="onUpdateTitleSetting"
@@ -52,7 +52,7 @@ await onLoad()
               @update="onUpdateTitleSetting"
             />
           </template>
-        </CommonEyecatchTitleSettingPositionFrame>
+        </CommonEyecatchTitleSettingPositionEyecatcher>
       </template>
       <template v-if="canEdit && eyecatchRef" #settings>
         <CommonEyecatchImageSetting

--- a/components/publish/home/type1/information.vue
+++ b/components/publish/home/type1/information.vue
@@ -24,7 +24,7 @@ await onLoad()
         class="eyecatcher"
       >
         <template #default>
-          <CommonEyecatchTitleSettingPositionFrame
+          <CommonEyecatchTitleSettingPosition
             :settings="informationRef?.titleSettings"
             :can-edit="canEdit"
             class="g-block-lg"
@@ -51,7 +51,7 @@ await onLoad()
                 @update="onUpdateTitleSetting"
               />
             </template>
-          </CommonEyecatchTitleSettingPositionFrame>
+          </CommonEyecatchTitleSettingPosition>
         </template>
         <template v-if="canEdit && informationRef" #settings>
           <CommonEyecatchImageSetting

--- a/components/publish/news/detail.vue
+++ b/components/publish/news/detail.vue
@@ -37,7 +37,7 @@ await onLoad(contentId)
           class="eyecatcher"
         >
           <template #default>
-            <CommonEyecatchTitleSettingPositionFrame
+            <CommonEyecatchTitleSettingPosition
               :settings="newsRef?.titleSettings"
               :can-edit="canEdit"
               class="g-block-lg"
@@ -57,7 +57,7 @@ await onLoad(contentId)
                   @update="onUpdateTitleSetting"
                 />
               </template>
-            </CommonEyecatchTitleSettingPositionFrame>
+            </CommonEyecatchTitleSettingPosition>
           </template>
           <template v-if="canEdit && newsRef" #settings>
             <CommonEyecatchImageSetting

--- a/components/publish/services/detail.vue
+++ b/components/publish/services/detail.vue
@@ -51,7 +51,7 @@ await onLoad(contentId)
           class="eyecatcher"
         >
           <template #default>
-            <CommonEyecatchTitleSettingPositionFrame
+            <CommonEyecatchTitleSettingPosition
               :settings="serviceRef?.titleSettings"
               :can-edit="canEdit"
               class="g-block-lg"
@@ -71,7 +71,7 @@ await onLoad(contentId)
                   @update="onUpdateTitleSetting"
                 />
               </template>
-            </CommonEyecatchTitleSettingPositionFrame>
+            </CommonEyecatchTitleSettingPosition>
           </template>
           <template v-if="canEdit && serviceRef" #settings>
             <CommonEyecatchImageSetting

--- a/composables/use-content/use-base-content.ts
+++ b/composables/use-content/use-base-content.ts
@@ -1,5 +1,9 @@
 import { debounce } from 'es-toolkit/compat'
-import type { TitleSettings, ImageSettings } from '@/types/content'
+import type {
+  EyecatchTitleSettings,
+  TitleSettings,
+  ImageSettings,
+} from '@/types/content'
 import type {
   ContentGetApi,
   ContentSaveApi,
@@ -417,7 +421,7 @@ export const useContentWrite = <
    */
   const updateTitleSettings = async (
     contentId: number,
-    titleSettings: TitleSettings
+    titleSettings: EyecatchTitleSettings | TitleSettings
   ): Promise<void> => {
     try {
       loading.value = true

--- a/composables/use-content/use-eyecatch-form.ts
+++ b/composables/use-content/use-eyecatch-form.ts
@@ -1,12 +1,13 @@
 import { cloneDeep } from 'es-toolkit'
 import { useForm, useField } from 'vee-validate'
 import type { EyecatchType, EyecatchForm } from '@/types/content'
+import { getEyecatchDefaultTitleSettings } from '@/composables/use-content/use-eyecatch'
 
 /**
  * Eyecatch Form
  */
 export const useEyecatchForm = () => {
-  const { getDefaultTitleSettings, getDefaultImageSettings } = useContentInit()
+  const { getDefaultImageSettings } = useContentInit()
   const { noBlank, maxLength } = useValidateRules()
 
   const eyecatchFormSchema = {
@@ -27,7 +28,7 @@ export const useEyecatchForm = () => {
   const eyecatchFormInitial: EyecatchForm = {
     title: '',
     subtitle: '',
-    titleSettings: getDefaultTitleSettings(),
+    titleSettings: getEyecatchDefaultTitleSettings(),
     image: '',
     imageName: '',
     imageType: '',

--- a/composables/use-content/use-eyecatch.ts
+++ b/composables/use-content/use-eyecatch.ts
@@ -1,20 +1,27 @@
 import type {
   EyecatchType,
   EyecatchForm,
-  TitleSettings,
+  EyecatchTitleSettings,
   ImageSettings,
 } from '@/types/content'
 import type { EyecatchGetApi, EyecatchSaveApi } from '@/types/API/content-api'
 
 const apiKind = 'eyecatches'
 export const getEyecatchKind = () => apiKind
+export const getEyecatchDefaultTitleSettings = (): EyecatchTitleSettings => ({
+  fontFamily: 'inherit',
+  color: '#FFFFFF',
+  bgColor: 'transparent',
+  position: '50% 50%',
+  positionSm: '50% 50%',
+  align: 'left',
+})
 
 const useEyecatchContent = (customerId: Ref<number | null>) => {
-  const { getDefaultTitleSettings, getDefaultImageSettings } = useContentInit()
+  const { getDefaultImageSettings } = useContentInit()
   const {
     loadData,
     get,
-    setTitleSettings,
     setImageSettings,
     contentDataRef,
     loadingRef: readLoading,
@@ -38,7 +45,7 @@ const useEyecatchContent = (customerId: Ref<number | null>) => {
           title: apiData.title,
           subtitle: apiData.subtitle,
           titleSettings: {
-            ...getDefaultTitleSettings(),
+            ...getEyecatchDefaultTitleSettings(),
             ...(apiData.titleSettings ? apiData.titleSettings : {}),
           },
           image: {
@@ -90,15 +97,17 @@ const useEyecatchContent = (customerId: Ref<number | null>) => {
     return apitypeToEyecatchType(data ?? null)
   }
 
-  const setEyecatchTitleSettings = (settings: Partial<TitleSettings>) => {
+  const setEyecatchTitleSettings = (
+    settings: Partial<EyecatchTitleSettings>
+  ) => {
     if (!eyecatchRef.value?.titleSettings) {
       return
     }
-    const newSettings: TitleSettings = {
+    const newSettings: EyecatchTitleSettings = {
       ...eyecatchRef.value.titleSettings,
       ...settings,
     }
-    setTitleSettings(newSettings)
+    eyecatchRef.value.titleSettings = { ...newSettings }
     return newSettings
   }
 
@@ -182,8 +191,8 @@ export const useEyecatchActions = (customerId: Ref<number | null>) => {
   }
 
   const onUpdateTitleSetting = (
-    settings: Partial<TitleSettings>
-  ): TitleSettings | undefined => {
+    settings: Partial<EyecatchTitleSettings>
+  ): EyecatchTitleSettings | undefined => {
     if (!eyecatchRef.value?.id) {
       return
     }

--- a/composables/use-window.ts
+++ b/composables/use-window.ts
@@ -47,3 +47,56 @@ export const useDetectIOS = () => {
 
   return { isIOS }
 }
+
+/**
+ * use can Handling Touche Event
+ */
+export const useDetectTouchDevice = () => {
+  const isTouchDevice = ref(false)
+  onMounted(() => {
+    if (import.meta.client) {
+      if ('ontouchstart' in window || navigator.maxTouchPoints) {
+        isTouchDevice.value = true
+      }
+    }
+  })
+
+  return { isTouchDevice }
+}
+
+/**
+ * Window Media Query
+ */
+export const useMediaQueryIsSmall = () => {
+  const isSmall = ref(false)
+  const isJudged = ref(false)
+  const mediaQuery = ref<MediaQueryList | null>(null)
+  const mediaQueryListner = (ev: MediaQueryListEvent) => {
+    isSmall.value = false
+    if (ev.matches) {
+      isSmall.value = true
+    }
+  }
+
+  onMounted(() => {
+    if (import.meta.client) {
+      mediaQuery.value = matchMedia('(max-width: 768px)')
+      if (mediaQuery.value.matches) {
+        isSmall.value = true
+      }
+      mediaQuery.value.addEventListener('change', mediaQueryListner)
+      isJudged.value = true
+    }
+  })
+
+  onBeforeUnmount(() => {
+    if (mediaQuery.value && import.meta.client) {
+      mediaQuery.value.removeEventListener('change', mediaQueryListner)
+    }
+  })
+
+  return {
+    isSmall,
+    isJudged,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "nuxt build --mode production",
-    "dev": "nuxt dev",
+    "dev": "NUXT_HOST=0.0.0.0 nuxt dev",
     "generate": "nuxt generate --mode production",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",

--- a/types/API/content-api.d.ts
+++ b/types/API/content-api.d.ts
@@ -1,5 +1,6 @@
 import type {
   TitleSettings,
+  EyecatchTitleSettings,
   ImageData,
   ImageSettings,
   MenuImageData,
@@ -24,6 +25,7 @@ export interface ContentGetApi {
 }
 
 export interface EyecatchGetApi extends ContentGetApi {
+  titleSettings?: EyecatchTitleSettings
   image: ImageData
   imageSettings: ImageSettings
 }
@@ -65,6 +67,7 @@ export type ContentSaveApi = {
 }
 
 export interface EyecatchSaveApi extends ContentSaveApi {
+  titleSettings: EyecatchTitleSettings
   image: ImageData
   imageSettings: ImageSettings
 }

--- a/types/content.d.ts
+++ b/types/content.d.ts
@@ -48,7 +48,11 @@ export interface ContentType {
   tags?: string[]
 }
 
+export interface EyecatchTitleSettings extends TitleSettings {
+  positionSm: string
+}
 export interface EyecatchType extends ContentType {
+  titleSettings: EyecatchTitleSettings
   image: ImageData
   imageSettings: ImageSettings
 }
@@ -91,6 +95,7 @@ export interface ContentForm {
   imageSettings?: ImageSettings | null
 }
 export interface EyecatchForm extends ContentForm {
+  titleSettings: EyecatchTitleSettings
   image: string
   imageName: string
   imageType: string


### PR DESCRIPTION
トップ Eyecaher 画像のタイトル titleSettings について、スマホ（小さい画面）とPC（大きい画面）で position 値を其々保持・変更できるように改造しました。

cf. #154