### PR TITLE
サービスや news のマウスやタッチスワイプでのページ遷移方式見直し

### DIFF
--- a/components/base/image-placer.vue
+++ b/components/base/image-placer.vue
@@ -4,6 +4,8 @@ const auto = defineModel<boolean>('auto', { required: true })
 const size = defineModel<number>('size', { required: true })
 const positionX = defineModel<number>('positionX', { required: true })
 const positionY = defineModel<number>('positionY', { required: true })
+
+withDefaults(defineProps<{ noParallax?: boolean }>(), { noParallax: false })
 </script>
 
 <template>
@@ -11,6 +13,7 @@ const positionY = defineModel<number>('positionY', { required: true })
     <li>
       <div class="pl-2">
         <v-switch
+          v-if="!noParallax"
           v-model="parallax"
           color="primary"
           density="compact"

--- a/components/common/content-slidable-navigation.vue
+++ b/components/common/content-slidable-navigation.vue
@@ -26,7 +26,6 @@ const router = useRouter()
 const isDragging = ref(false)
 const startX = ref(0)
 const offsetX = ref(0)
-const page = ref(-1)
 
 const endMove = () => {
   if (!isDragging.value) {
@@ -34,14 +33,12 @@ const endMove = () => {
   }
   isDragging.value = false
 
-  if (offsetX.value > 100) {
-    if (page.value < 0 && props.preUrl) {
-      page.value++
+  if (offsetX.value > 120) {
+    if (props.preUrl) {
       router.push(props.preUrl)
     }
-  } else if (offsetX.value < -100) {
-    if (page.value > -2 && props.nextUrl) {
-      page.value--
+  } else if (offsetX.value < -120) {
+    if (props.nextUrl) {
       router.push(props.nextUrl)
     }
   }
@@ -119,13 +116,13 @@ const onTouchEnd = () => {
   endMove()
 }
 
-const translation = computed(() => `${page.value * 100}% + ${offsetX.value}px`)
+const translation = computed(() => `-100% + ${offsetX.value}px`)
 const columnCursor = computed(() => (isDragging.value ? 'grabbing' : 'grab'))
 </script>
 
 <template>
   <div
-    class="content-wrap-slidable"
+    class="content-slidable-navigation"
     @mousedown.stop="onMouseDown"
     @mouseup.stop="onMouseUp"
     @mousemove.stop="onMouseMove"
@@ -134,81 +131,70 @@ const columnCursor = computed(() => (isDragging.value ? 'grabbing' : 'grab'))
     @touchmove.stop="onTouchMove"
     @touchend.stop="onTouchEnd"
   >
-    <div
-      class="slidable pre-next"
-      :class="{ 'with-transition': !isTouchDevice }"
-    >
-      <div
-        class="g-theme-slidable-item"
-        :class="[preUrl ? 'has-item' : 'no-item']"
-      >
-        <h3 v-show="preUrl" style="text-align: right">
-          <v-icon icon="mdi-arrow-left-drop-circle" :size="38" />
-          ・・・前へ
-        </h3>
+    <div class="slidable-container">
+      <div class="slidable pre-next">
+        <div
+          class="g-theme-slidable-item"
+          :class="[preUrl ? 'has-item' : 'no-item']"
+        >
+          <h3 v-show="preUrl" style="text-align: right">
+            <v-icon icon="mdi-arrow-left-drop-circle" :size="38" />
+            ・・・前へ
+          </h3>
+        </div>
       </div>
-    </div>
-    <div
-      id="slidable-target"
-      ref="slidableTargetRef"
-      class="slidable target"
-      :class="{ 'with-transition': !isTouchDevice }"
-    >
-      <slot />
-    </div>
-    <div
-      class="slidable pre-next"
-      :class="{ 'with-transition': !isTouchDevice }"
-    >
-      <div
-        class="g-theme-slidable-item"
-        :class="[nextUrl ? 'has-item' : 'no-item']"
-      >
-        <h3 v-show="nextUrl">
-          次へ・・・
-          <v-icon icon="mdi-arrow-right-drop-circle" :size="38" />
-        </h3>
+      <div id="slidable-target" ref="slidableTargetRef" class="slidable target">
+        <slot />
+      </div>
+      <div class="slidable pre-next">
+        <div
+          class="g-theme-slidable-item"
+          :class="[nextUrl ? 'has-item' : 'no-item']"
+        >
+          <h3 v-show="nextUrl">
+            次へ・・・
+            <v-icon icon="mdi-arrow-right-drop-circle" :size="38" />
+          </h3>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
-.content-wrap-slidable {
+.content-slidable-navigation {
   width: 100%;
   overflow: hidden;
-  white-space: nowrap;
   cursor: v-bind('columnCursor');
 
-  .slidable {
-    display: inline-block;
-    padding: 0;
-    width: 100%;
-    min-height: 50vh;
-    white-space: normal;
-    vertical-align: top;
+  .slidable-container {
+    display: flex;
     transform: translateX(calc(v-bind('translation')));
-  }
 
-  .pre-next {
-    padding: 0 3rem;
+    .slidable {
+      display: block;
+      flex: 0 0 100%;
+      padding: 0;
+      width: 100%;
+      min-height: 400px;
+    }
 
-    .has-item {
-      height: v-bind('`${slidableCenterHeight}px`');
-      padding: 2rem;
-      border-radius: 1rem;
+    .pre-next {
+      padding: 0 3rem;
 
-      @media only screen and (max-width: $grid-breakpoint-md) {
-        border-radius: 0.25rem;
+      .has-item {
+        height: v-bind('`${slidableCenterHeight}px`');
+        padding: 2rem;
+        border-radius: 1rem;
+
+        @media only screen and (max-width: $grid-breakpoint-md) {
+          border-radius: 0.25rem;
+        }
+      }
+      .no-item {
+        background-color: transparent;
       }
     }
-    .no-item {
-      background-color: transparent;
-    }
   }
-
-  // .with-transition {
-  //   transition: transform 0;
-  // }
 }
 </style>

--- a/components/common/eyecatch-image-setting.vue
+++ b/components/common/eyecatch-image-setting.vue
@@ -1,16 +1,20 @@
 <script setup lang="ts">
 import type { ImageSettings } from '@/types/content'
 
-const props = withDefaults(defineProps<{ settings?: ImageSettings }>(), {
-  settings: () => ({
-    lgSize: 'cover',
-    smSize: 'cover',
-    lgPosition: 'center',
-    smPosition: 'center',
-    lgParallax: 'scroll',
-    smParallax: 'scroll',
-  }),
-})
+const props = withDefaults(
+  defineProps<{ settings?: ImageSettings; noParallax?: boolean }>(),
+  {
+    settings: () => ({
+      lgSize: 'cover',
+      smSize: 'cover',
+      lgPosition: 'center',
+      smPosition: 'center',
+      lgParallax: 'scroll',
+      smParallax: 'scroll',
+    }),
+    noParallax: false,
+  }
+)
 const emit = defineEmits<{
   update: [partOfSettings: Partial<ImageSettings>]
 }>()
@@ -187,6 +191,7 @@ const settingMenu = ref(false)
         v-model:size="sizeLg"
         v-model:position-x="pxLg"
         v-model:position-y="pyLg"
+        :no-parallax="noParallax"
         class="g-block-lg"
       />
       <!-- Small画面 -->
@@ -196,6 +201,7 @@ const settingMenu = ref(false)
         v-model:size="sizeSm"
         v-model:position-x="pxSm"
         v-model:position-y="pySm"
+        :no-parallax="noParallax"
         class="g-block-sm"
       />
       <div class="actions">

--- a/components/publish/news/detail.vue
+++ b/components/publish/news/detail.vue
@@ -92,6 +92,7 @@ await onLoad(contentId)
               <template v-if="canEdit && newsRef" #settings>
                 <CommonEyecatchImageSetting
                   :settings="newsRef.imageSettings"
+                  no-parallax
                   @update="onUpdateImageSetting"
                 />
               </template>

--- a/components/publish/services/detail.vue
+++ b/components/publish/services/detail.vue
@@ -107,6 +107,7 @@ await onLoad(contentId)
               <template v-if="canEdit && serviceRef" #settings>
                 <CommonEyecatchImageSetting
                   :settings="serviceRef.imageSettings"
+                  no-parallax
                   @update="onUpdateImageSetting"
                 />
               </template>


### PR DESCRIPTION
サービスや news のマウスやタッチスワイプでのページ遷移方式見直し
およびホーム画面以外のアイキャッチ画像は pralax 設定をできないように修正した

cf. #176 
cf. #177