### PR TITLE
詳細画面などへのリンクボタンを追加して導線をわかりやすく スマホのみ

### DIFF
--- a/components/publish/features/list/item-row.vue
+++ b/components/publish/features/list/item-row.vue
@@ -55,6 +55,9 @@ const route = useRoute()
             {{ item.title }}
           </h5>
           <CommonWysiwsgViewer :value="item.caption" class="caption" />
+          <p class="g-block-sm mt-2 text-right">
+            <v-btn variant="outlined" size="small">詳しく見る</v-btn>
+          </p>
         </div>
       </CommonContentItemAnimation>
     </section>

--- a/components/publish/home/type1/newses.vue
+++ b/components/publish/home/type1/newses.vue
@@ -116,7 +116,7 @@ await onLoad()
         </div>
       </CommonContentCardBody>
       <div class="type1-news-list__action">
-        <NuxtLink to="/news">and more ...</NuxtLink>
+        <NuxtLink to="/news">もっと見る ...</NuxtLink>
       </div>
       <div v-if="canEdit && newsListRef?.length" class="create-activator">
         <ManageContentNews @create="onCreate" />
@@ -130,7 +130,7 @@ await onLoad()
   position: relative;
   min-height: 16rem;
   &__action {
-    margin: 1.5rem 0;
+    margin-bottom: 1.25rem;
     text-align: center;
   }
   .no-items {

--- a/components/publish/services/list/item.vue
+++ b/components/publish/services/list/item.vue
@@ -54,6 +54,9 @@ const route = useRoute()
         :disabled="route.name !== 'index'"
       >
         <CommonWysiwsgViewer :value="item.caption" class="caption" />
+        <p class="g-block-sm mt-2 text-right">
+          <v-btn variant="outlined" size="small">詳しく見る</v-btn>
+        </p>
       </CommonContentItemAnimation>
     </section>
   </div>


### PR DESCRIPTION
詳細画面などへのリンクボタンを追加して導線をわかりやすく スマホのみ

#194 