### PR TITLE
contents grid で2個の時で、タイトル文字列の長さが長い時に item のサイズが大きくなる問題修正

### DIFF
--- a/components/common/content-grid-draggable.vue
+++ b/components/common/content-grid-draggable.vue
@@ -59,7 +59,9 @@ const columnCursor = computed(() => (isDragging.value ? 'grabbing' : 'grab'))
       >
         <template #item="{ element }">
           <div class="column column-draggable g-theme-contents-item__draggable">
-            <slot :content="element" />
+            <div class="column-element">
+              <slot :content="element" />
+            </div>
             <div
               class="edit-position-top draggable g-theme-contents-item__draggable--notion"
             >
@@ -158,8 +160,13 @@ $grid-max-width: $contents-card-max-width;
   margin: 0 auto;
 
   .column {
-    flex: 0 1 calc($grid-max-width / v-bind('flexColumnDivide') - 1.25rem);
-    padding: 1.5rem 0.75rem 2.5rem 0.75rem;
+    flex: 0 0 calc($grid-max-width / v-bind('flexColumnDivide') - 1.25rem);
+
+    .column-element {
+      width: calc($grid-max-width / v-bind('flexColumnDivide') - 1.25rem);
+      max-width: calc($grid-max-width / v-bind('flexColumnDivide') - 1.25rem);
+      padding: 1.5rem 0.75rem 2.5rem 0.75rem;
+    }
   }
 }
 </style>

--- a/components/common/content-grid.vue
+++ b/components/common/content-grid.vue
@@ -50,7 +50,9 @@ const columnGap = computed(() =>
   <div>
     <div :class="{ 'content-grid': useGrid, 'content-grid-flex': !useGrid }">
       <div v-for="content in contents" :key="content.id" class="column">
-        <slot :content="content" />
+        <div class="column-element">
+          <slot :content="content" />
+        </div>
       </div>
     </div>
   </div>
@@ -95,8 +97,13 @@ $grid-max-width: $contents-card-max-width;
   margin: 0 auto;
 
   .column {
-    flex: 0 1 calc($grid-max-width / v-bind('flexColumnDivide') - 1.25rem);
-    padding: 0;
+    flex: 0 0 calc($grid-max-width / v-bind('flexColumnDivide') - 1.25rem);
+
+    .column-element {
+      width: calc($grid-max-width / v-bind('flexColumnDivide') - 1.25rem);
+      max-width: calc($grid-max-width / v-bind('flexColumnDivide') - 1.25rem);
+      padding: 0;
+    }
   }
 }
 </style>


### PR DESCRIPTION
contents grid で2個の時で、タイトル文字列の長さが長い時に item のサイズが大きくなる問題を修正しました。

flex shrink や flex grow は 0 にしても、子要素が文字長により広がってしまうので、直下の子要素に wdith と max-width を強制的にセットして問題を解決した。

cf. #231